### PR TITLE
refeactor: Entity에서 상속을 해서 사용하는 목적에 맞게 abstract 키워드 추가

### DIFF
--- a/src/main/java/org/example/board/domain/AuditingFields.java
+++ b/src/main/java/org/example/board/domain/AuditingFields.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @ToString
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public class AuditingFields {
+public abstract class AuditingFields {
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate


### PR DESCRIPTION
(해당 커밋은 별도 issue 없이 작업 진행함)
- @MappedSuperclass의 애노테이션을 가진 클래스는 Entity가 아님
- 혼자서는 Entity가 될 수 없고 다른 Entity가 상속시 추가 필드로서 들어감
- 이를 명확하게 하기 위해 abstact 키워드를 추가함